### PR TITLE
Update to Go 1.11 runtime.

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,0 +1,9 @@
+.git/
+.gitignore
+*~
+*.back
+.*.swp
+*.yaml
+pkg/
+makepkg.sh
+README.md

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ goapp serve
 Specify GCP project id and api tokens (comma separated).
 
 ```
-appcfg.py -A YOUR-PROJECT-ID -E GCLOUD_PROJECT:YOUR-PROJECT-ID -E API_TOKEN:XXXXXXXX update .
+gcloud --project=YOUR-PROJECT-ID app deploy app.yaml
 ```
 
 ## Upload package to deploy via Google App Engine Admin API

--- a/magellan-log-collector.go
+++ b/magellan-log-collector.go
@@ -50,7 +50,7 @@ type Output struct {
 }
 
 func postHandler(w http.ResponseWriter, r *http.Request) {
-	ctx := r.Context();
+	ctx := r.Context()
 	output := Output{false, "something wrong."}
 	code := 500
 


### PR DESCRIPTION
- use Go standard log package instead of appengine sdk
- add main() function.
- use http.Request.Context() instead of appengine sdk

ref. https://cloud.google.com/appengine/docs/standard/go111/go-differences