### PR TITLE
remove redundant logging.

### DIFF
--- a/magellan-log-collector.go
+++ b/magellan-log-collector.go
@@ -128,7 +128,6 @@ func postHandler(w http.ResponseWriter, r *http.Request) {
 				},
 			},
 		}
-		log.Printf("publish data = %v", string(json))
 		if _, err := pubsubService.Projects.Topics.Publish(topicId, msg).Do(); err != nil {
 			output.Message = fmt.Sprintf("Could not publish message: %v", err)
 			log.Printf("Could not publish message: %v", err)


### PR DESCRIPTION
magellan-log-collector emit log messages for all message payloads with its contents.
It's redundant and heavily burden cost of Cloud Logging.
I eliminate the logging in the normal pass.